### PR TITLE
add import/core-modules rule for electron

### DIFF
--- a/eslint-config-innovatrics-base/index.js
+++ b/eslint-config-innovatrics-base/index.js
@@ -54,5 +54,10 @@ module.exports = {
     // are numbers, then airbnb wants them unquoted, and flow
     // wants them quoted. and we cannot change it in flow.
     'quote-props': ['error', 'as-needed', { keywords: false, unnecessary: true, numbers: true }]
-  }
+  },
+  // import electron from 'electron' errors because it's in devDependencies, this rule fixes it
+  // see: https://github.com/benmosher/eslint-plugin-import/issues/422
+  "settings": {
+    "import/core-modules": ["electron"],
+  },
 };

--- a/eslint-config-innovatrics-base/package.json
+++ b/eslint-config-innovatrics-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innovatrics/eslint-config-innovatrics-base",
-  "version": "12.1.0-build.1",
+  "version": "12.1.0-build.2",
   "description": "Innovatrics base JS ESLINT config, following our styleguide",
   "main": "index.js",
   "author": "Innovatrics, s.r.o.",

--- a/eslint-config-innovatrics/index.js
+++ b/eslint-config-innovatrics/index.js
@@ -75,5 +75,10 @@ module.exports = {
         "render"
       ]
     }],
-  }
+  },
+  // import electron from 'electron' errors because it's in devDependencies, this rule fixes it
+  // see: https://github.com/benmosher/eslint-plugin-import/issues/422
+  "settings": {
+    "import/core-modules": ["electron"],
+  },
 };

--- a/eslint-config-innovatrics/package.json
+++ b/eslint-config-innovatrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innovatrics/eslint-config-innovatrics",
-  "version": "16.1.0-build.1",
+  "version": "16.1.0-build.2",
   "description": "Innovatrics JS ESLINT config, following our styleguide",
   "main": "index.js",
   "author": "Innovatrics, s.r.o.",


### PR DESCRIPTION
Fix `import/no-extraneous-dependencies` error with electron installed in `devDependencies` by adding rule `import/core-modules` with `electron`, see: https://github.com/benmosher/eslint-plugin-import/issues/422