### PR TITLE
add/remove some rules, fix react-hooks plugin include

### DIFF
--- a/eslint-config-innovatrics-base/package.json
+++ b/eslint-config-innovatrics-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innovatrics/eslint-config-innovatrics-base",
-  "version": "14.2.0-build.1",
+  "version": "14.2.0-build.2",
   "description": "Innovatrics base JS ESLINT config, following our styleguide",
   "main": "index.js",
   "author": "Innovatrics, s.r.o.",

--- a/eslint-config-innovatrics-typescript-base/index.js
+++ b/eslint-config-innovatrics-typescript-base/index.js
@@ -59,6 +59,13 @@ module.exports = {
     // see this for a discussion: https://github.com/airbnb/javascript/issues/1135
     "import/prefer-default-export": "off",
 
+    // sometimes the variable has the underscore at the beginning,
+    // for example `__typename` in graphql.
+    // also, prefixing a method-name with `_` is a simple way to
+    // signalize that a method is private-ish, without having
+    // to enforce it.
+    "no-underscore-dangle": "off",
+
     // We have added Storybook .story files [Innovatrics]
     // Forbid the use of extraneous packages
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-extraneous-dependencies.md
@@ -105,6 +112,8 @@ module.exports = {
     // but those cases seem to be rare (and we will just disable
     // the rule for that line of code)
     "@typescript-eslint/consistent-type-definitions": ["error", "type"],
+    // we turn this one off, because the next rule (naming-convention) takes care of this
+    camelcase: "off",
     // @typescript-esling changed `camelcase` rule to `naming-convention`
     // we allow UPPER_CASE for QUERY variables (GraphQL) and PascalCase for React components
     // typeLike is always PascalCase (type ImageFormat = ...)
@@ -120,5 +129,32 @@ module.exports = {
     // renamed `ban-ts-ignore`
     // we don't allow usage of `@ts-ignore` and such
     "@typescript-eslint/ban-ts-comment": 2,
+
+    // every dependency is a dev-dependency for us,
+    // because we build every production-thing
+    // into it's own bundle, both the server and client.
+    // so we have to allow importing-from-dev-dependencies.
+    // later we might move this override into the innovatrics
+    // ruleset.
+    "import/no-extraneous-dependencies": [
+      "error",
+      {
+        devDependencies: true,
+        optionalDependencies: false,
+        peerDependencies: false,
+        bundledDependencies: false,
+      },
+    ],
+    // --------------------------------------------------------------------------
+    // Rules under this line are extensions over 'eslint-config-innovatrics'
+
+    "import/extensions": [
+      "error",
+      "always",
+      {
+        js: "never",
+        ts: "never",
+      },
+    ],
   },
 };

--- a/eslint-config-innovatrics-typescript-base/package.json
+++ b/eslint-config-innovatrics-typescript-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innovatrics/eslint-config-innovatrics-typescript-base",
-  "version": "14.2.0-build.1",
+  "version": "14.2.0-build.2",
   "description": "Innovatrics base TS ESLINT config, following our styleguide",
   "main": "index.js",
   "author": "Innovatrics, s.r.o.",

--- a/eslint-config-innovatrics-typescript/index.js
+++ b/eslint-config-innovatrics-typescript/index.js
@@ -2,7 +2,11 @@ module.exports = {
   root: true,
   parser: "@typescript-eslint/parser",
   plugins: ["@typescript-eslint", "import"],
-  extends: ["airbnb", "plugin:@typescript-eslint/recommended"],
+  extends: [
+    "airbnb",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:react-hooks/recommended",
+  ],
   settings: {
     "import/resolver": {
       typescript: {},
@@ -59,6 +63,13 @@ module.exports = {
     // see this for a discussion: https://github.com/airbnb/javascript/issues/1135
     "import/prefer-default-export": "off",
 
+    // sometimes the variable has the underscore at the beginning,
+    // for example `__typename` in graphql.
+    // also, prefixing a method-name with `_` is a simple way to
+    // signalize that a method is private-ish, without having
+    // to enforce it.
+    "no-underscore-dangle": "off",
+
     // We have added Storybook .story files [Innovatrics]
     // Forbid the use of extraneous packages
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-extraneous-dependencies.md
@@ -105,6 +116,8 @@ module.exports = {
     // but those cases seem to be rare (and we will just disable
     // the rule for that line of code)
     "@typescript-eslint/consistent-type-definitions": ["error", "type"],
+    // we turn this one off, because the next rule (naming-convention) takes care of this
+    camelcase: "off",
     // @typescript-esling changed `camelcase` rule to `naming-convention`
     // we allow UPPER_CASE for QUERY variables (GraphQL) and PascalCase for React components
     // typeLike is always PascalCase (type ImageFormat = ...)
@@ -121,8 +134,33 @@ module.exports = {
     // we don't allow usage of `@ts-ignore` and such
     "@typescript-eslint/ban-ts-comment": 2,
 
+    // every dependency is a dev-dependency for us,
+    // because we build every production-thing
+    // into it's own bundle, both the server and client.
+    // so we have to allow importing-from-dev-dependencies.
+    // later we might move this override into the innovatrics
+    // ruleset.
+    "import/no-extraneous-dependencies": [
+      "error",
+      {
+        devDependencies: true,
+        optionalDependencies: false,
+        peerDependencies: false,
+        bundledDependencies: false,
+      },
+    ],
     // --------------------------------------------------------------------------
     // Rules under this line are extensions over 'eslint-config-innovatrics'
+
+    "import/extensions": [
+      "error",
+      "always",
+      {
+        js: "never",
+        ts: "never",
+        tsx: "never",
+      },
+    ],
 
     // the airbnb-rules say that a label has to
     // BOTH have an htmlFor attribute, and have

--- a/eslint-config-innovatrics-typescript/package.json
+++ b/eslint-config-innovatrics-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innovatrics/eslint-config-innovatrics-typescript",
-  "version": "18.2.0-build.1",
+  "version": "18.2.0-build.2",
   "description": "Innovatrics TS ESLINT config, following our styleguide",
   "main": "index.js",
   "author": "Innovatrics, s.r.o.",

--- a/eslint-config-innovatrics/index.js
+++ b/eslint-config-innovatrics/index.js
@@ -1,7 +1,7 @@
 // FIXME duplicit eslint config
 module.exports = {
   root: true,
-  extends: "airbnb",
+  extends: ["airbnb", "plugin:react-hooks/recommended"],
   parser: "babel-eslint",
   plugins: ["flowtype"],
 
@@ -83,6 +83,15 @@ module.exports = {
 
     // --------------------------------------------------------------------------
     // Rules under this line are extensions over 'eslint-config-innovatrics'
+
+    "import/extensions": [
+      "error",
+      "always",
+      {
+        js: "never",
+        jsx: "never",
+      },
+    ],
 
     // the airbnb-rules say that a label has to
     // BOTH have an htmlFor attribute, and have

--- a/eslint-config-innovatrics/package.json
+++ b/eslint-config-innovatrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innovatrics/eslint-config-innovatrics",
-  "version": "18.2.0-build.1",
+  "version": "18.2.0-build.2",
   "description": "Innovatrics JS ESLINT config, following our styleguide",
   "main": "index.js",
   "author": "Innovatrics, s.r.o.",


### PR DESCRIPTION
- add some rules from other projects we have so it's unified. 
- turned off `camelcase` rule as `@typescript-eslint/naming-convention` takes care of that now.
- fixed `eslint-plugin-react-hooks` being not included in the config
  - also used `:recommended` rules for react hooks